### PR TITLE
Optimize jade_escape

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,13 +183,26 @@ var jade_encode_html_rules = {
   '"': '&quot;'
 };
 var jade_match_html = /[&<>"]/g;
+/* istanbul ignore next */
 function jade_encode_char(c) {
   return jade_encode_html_rules[c] || c;
 }
 exports.escape = jade_escape;
-function jade_escape(html){
-  var result = String(html).replace(jade_match_html, jade_encode_char);
-  if (result === '' + html) return html;
+function jade_escape(_html){
+  var html = String(_html);
+  var result = '';
+  var i, lastIndex;
+  for (i = 0, lastIndex = 0; i < html.length; i++) {
+    var c = html[i];
+    if (c === '&' || c === '<' || c === '>' || c === '"') {
+      if (lastIndex !== i) result += html.substring(lastIndex, i);
+      result += jade_encode_html_rules[c];
+      lastIndex = i + 1;
+    }
+  }
+  if (lastIndex !== i) result += html.substring(lastIndex, i);
+
+  if (html === result) return _html;
   else return result;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -93,6 +93,7 @@ test('escape', function (escape) {
   assert(escape('foo&<bar') === 'foo&amp;&lt;bar');
   assert(escape('foo&<>bar') === 'foo&amp;&lt;&gt;bar');
   assert(escape('foo&<>"bar') === 'foo&amp;&lt;&gt;&quot;bar');
+  assert(escape('foo&<>"bar"') === 'foo&amp;&lt;&gt;&quot;bar&quot;');
 });
 
 test('merge', function (merge) {


### PR DESCRIPTION
`jade_match_html` and `jade_encode_char` are now unused but kept for compatibility.

```
Input                      | Time per 10^7 run (ms)
---------------------------|-----------------------
'adfs<a&>asdafd'           |  6946 => 2323
'asdfsfdafdsadsfpafsdfdsa' |  1529 => 1382
'asdfsfdafdsadsf&afsdfdsa' |  5510 => 2152
'<<&&&>>>>>><<>""<'        | 17521 => 3542
```
