### PR TITLE
Further optimize jade_escape

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,20 +198,22 @@ function jade_encode_char(c) {
 }
 exports.escape = jade_escape;
 function jade_escape(_html){
-  var html = String(_html);
+  var html = '' + _html;
   var result = '';
-  var i, lastIndex;
+  var i, lastIndex, c, escape;
   for (i = 0, lastIndex = 0; i < html.length; i++) {
-    var c = html[i];
-    if (c === '&' || c === '<' || c === '>' || c === '"') {
+    c = html[i];
+    if ((c === '&' && (escape = '&amp;')) ||
+        (c === '<' && (escape = '&lt;')) ||
+        (c === '>' && (escape = '&gt;')) ||
+        (c === '"' && (escape = '&quot;'))) {
       if (lastIndex !== i) result += html.substring(lastIndex, i);
-      result += jade_encode_html_rules[c];
       lastIndex = i + 1;
+      result += escape;
     }
   }
-  if (lastIndex !== i) result += html.substring(lastIndex, i);
-
-  if (html === result) return _html;
+  if (!result) return html;
+  else if (lastIndex !== i) return result + html.substring(lastIndex, i);
   else return result;
 };
 

--- a/index.js
+++ b/index.js
@@ -203,17 +203,18 @@ function jade_escape(_html){
   if (!regexResult) return _html;
 
   var result = '';
-  var i, lastIndex, c, escape;
+  var i, lastIndex, escape;
   for (i = regexResult.index, lastIndex = 0; i < html.length; i++) {
-    c = html[i];
-    if ((c === '&' && (escape = '&amp;')) ||
-        (c === '<' && (escape = '&lt;')) ||
-        (c === '>' && (escape = '&gt;')) ||
-        (c === '"' && (escape = '&quot;'))) {
-      if (lastIndex !== i) result += html.substring(lastIndex, i);
-      lastIndex = i + 1;
-      result += escape;
+    switch (html[i]) {
+      case '&': escape = '&amp;'; break;
+      case '<': escape = '&lt;'; break;
+      case '>': escape = '&gt;'; break;
+      case '"': escape = '&quot;'; break;
+      default: continue;
     }
+    if (lastIndex !== i) result += html.substring(lastIndex, i);
+    lastIndex = i + 1;
+    result += escape;
   }
   if (lastIndex !== i) return result + html.substring(lastIndex, i);
   else return result;

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ var jade_encode_html_rules = {
   '>': '&gt;',
   '"': '&quot;'
 };
-var jade_match_html = /[&<>"]/g;
+var jade_match_html = /[&<>"]/;
 /* istanbul ignore next */
 function jade_encode_char(c) {
   return jade_encode_html_rules[c] || c;
@@ -199,9 +199,12 @@ function jade_encode_char(c) {
 exports.escape = jade_escape;
 function jade_escape(_html){
   var html = '' + _html;
+  var regexResult = jade_match_html.exec(html);
+  if (!regexResult) return _html;
+
   var result = '';
   var i, lastIndex, c, escape;
-  for (i = 0, lastIndex = 0; i < html.length; i++) {
+  for (i = regexResult.index, lastIndex = 0; i < html.length; i++) {
     c = html[i];
     if ((c === '&' && (escape = '&amp;')) ||
         (c === '<' && (escape = '&lt;')) ||
@@ -212,8 +215,7 @@ function jade_escape(_html){
       result += escape;
     }
   }
-  if (!result) return html;
-  else if (lastIndex !== i) return result + html.substring(lastIndex, i);
+  if (lastIndex !== i) return result + html.substring(lastIndex, i);
   else return result;
 };
 


### PR DESCRIPTION
This optimization loses a little bit of performance for strings that do not need escaping (4%) but we gain 10% - 45% speed on strings that do need escaping.

| Input | Ops/sec |
| --- | --- |
| 'adfs<&>asdafd' | 4,529,925 => 5,497,796 |
| 'asdfsfdafdsadsfpafsdfdsa' | 7,290,450 => 7,022,728 |
| 'asdfsfdafdsadsf&afsdfdsa' | 5,054,397 => 5,555,558 |
| '<<&&&>>>>>><<>""<' | 2,917,407 => 4,277,800 |
