### PR TITLE
Remove old code

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,17 +185,6 @@ function jade_attrs(obj, terse){
  * @api private
  */
 
-var jade_encode_html_rules = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;'
-};
-var jade_match_html = /[&<>"]/g;
-/* istanbul ignore next */
-function jade_encode_char(c) {
-  return jade_encode_html_rules[c] || c;
-}
 exports.escape = jade_escape;
 function jade_escape(_html){
   var html = String(_html);


### PR DESCRIPTION
This removes `jade_encode_html_rules`, `jade_match_html` and `jade_encode_char`.
There were deprecated by https://github.com/jadejs/jade-runtime/pull/7 and https://github.com/jadejs/jade-runtime/pull/8. Since they are internal, I believe we should remove them for good.
