### PR TITLE
Updated uglify-js to 2.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "istanbul": "^0.3.5",
     "testit": "^2.0.2",
-    "uglify-js": "^2.4.16"
+    "uglify-js": "^2.4.24"
   },
   "files": [
     "build.js",


### PR DESCRIPTION
The article at https://zyan.scripts.mit.edu/blog/backdooring-js/ explains how one can leverage a bug in UglifyJS 2.4.23 and earlier to introduce security issues that manifest only in minified code.
