### PR TITLE
Add a wrap module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   now been removed. Please note that any further changes to these internal
   variables will not come with a major bump.
 
+### Added
+- A new module `require('jade-runtime/wrap')` is added to ease testing
+  client-side templates.
+
 ## 1.1.0 - 2015-07-09
 ### Changed
 - `escape()` has been optimized, making it about 20-30% faster. The new

--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ var attr = Function('', src + ';return jade_attr;')();
 assert(attr('foo', 'bar', true, true) === ' foo="bar"');
 ```
 
+When testing code compiled for the browser in Node.js, it is necessary to make the runtime available. To do so, one can use `require('jade-runtime/wrap')`:
+
+```js
+var jade = require('jade');
+var wrap = require('jade-runtime/wrap');
+
+var jadeSrc = 'p= body';
+// By default compileClient automatically embeds the needed runtime functions,
+// rendering this module useless.
+var compiledCode = jade.compileClient(jadeSrc, {
+  externalRuntime: true
+});
+//=> 'function template (locals) { ... jade.escape() ... }'
+
+var templateFunc = wrap(compiledCode);
+templateFunc({body: 'Hey!'});
+//=> '<p>Hey!</p>'
+
+// Change template function name to 'heyTemplate'
+compiledCode = jade.compileClient(jadeSrc, {
+  externalRuntime: true,
+  name: 'heyTemplate'
+});
+//=> 'function heyTemplate (locals) { ... }'
+
+templateFunc = wrap(compiledCode, 'heyTemplate');
+templateFunc({body: 'Hey!'});
+//=> '<p>Hey!</p>'
+```
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lib/match_html.js",
     "lib/merge.js",
     "lib/rethrow.js",
-    "lib/style.js"
+    "lib/style.js",
+    "wrap.js"
   ],
   "scripts": {
     "prepublish": "node prepublish",

--- a/prepublish.js
+++ b/prepublish.js
@@ -7,6 +7,7 @@ var runtime = require('./');
 var files = [
   'index.js',
   'build.js',
+  'wrap.js',
   'lib/dependencies.js',
   'lib/internals.js'
 ];

--- a/test/index.js
+++ b/test/index.js
@@ -4,12 +4,14 @@ var assert = require('assert');
 var testit = require('testit');
 var runtime = require('../');
 var build = require('../build');
+var wrap = require('../wrap');
 
 function test(name, fn) {
   testit(name, function () {
 
     fn(runtime[name]);
     fn(Function('', build([name]) + ';return jade_' + name + ';')());
+    fn(wrap('function t() {return jade.' + name + ';}', 't')())
   });
 }
 

--- a/wrap.js
+++ b/wrap.js
@@ -1,0 +1,10 @@
+var runtime = require('./');
+
+module.exports = wrap;
+function wrap(template, templateName) {
+  templateName = templateName || 'template';
+  return Function('jade',
+    template + '\n' +
+    'return ' + templateName + ';'
+  )(runtime);
+}


### PR DESCRIPTION
Allows one to do:

``` js
var jadeSrc = 'p= body';
// By default compileClient automatically embeds the needed runtime
functions,
// rendering this module useless.
var compiledCode = jade.compileClient(jadeSrc, {
  externalRuntime: true
});
//=> 'function template (locals) { ... jade.escape() ... }'

var templateFunc = wrap(compiledCode);
templateFunc({body: 'Hey!'});
//=> '<p>Hey!</p>'
```

There are plenty of places where this can be used:
- https://github.com/jadejs/jade/blob/master/lib/index.js#L178
- https://github.com/jadejs/jade/blob/master/test/run.js#L70-L78
- https://github.com/jadejs/jade/blob/master/test/jade.test.js#L1069-L1103
