### PR TITLE
Tell browser bundlers to ignore "fs" requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "type": "git",
     "url": "https://github.com/pugjs/pug-runtime.git"
   },
+  "browser": {
+    "fs": false
+  },
   "author": "ForbesLindesay",
   "license": "MIT"
 }


### PR DESCRIPTION
The only function where fs is used has a "plan B" in case it's not available.
