### PR TITLE
inline styles should end with semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function pug_merge(a, b) {
     } else if (key === 'style') {
       var valA = pug_style(a[key]);
       var valB = pug_style(b[key]);
-      a[key] = valA + (valA && valB && ';') + valB;
+      a[key] = valA + valB;
     } else {
       a[key] = b[key];
     }
@@ -100,18 +100,17 @@ exports.style = pug_style;
 function pug_style(val) {
   if (!val) return '';
   if (typeof val === 'object') {
-    var out = '', delim = '';
+    var out = '';
     for (var style in val) {
       /* istanbul ignore else */
       if (pug_has_own_property.call(val, style)) {
-        out = out + delim + style + ':' + val[style];
-        delim = ';';
+        out = out + style + ':' + val[style] + ';';
       }
     }
     return out;
   } else {
-    val = '' + val;
-    if (val[val.length - 1] === ';') return val.slice(0, -1);
+    if (val[val.length - 1] !== ';') 
+      return val + ';';
     return val;
   }
 };

--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ function pug_style(val) {
     }
     return out;
   } else {
+    val += '';
     if (val[val.length - 1] !== ';') 
       return val + ';';
     return val;

--- a/test/index.js
+++ b/test/index.js
@@ -80,10 +80,10 @@ test('attrs', function (attrs) { // (obj, terse)
   assert(attrs({class: ['foo', {bar: true}]}, false) === ' class="foo bar"');
   assert(attrs({class: ['foo', {bar: true}], foo: 'bar'}, true) === ' class="foo bar" foo="bar"');
   assert(attrs({foo: 'bar', class: ['foo', {bar: true}]}, false) === ' class="foo bar" foo="bar"');
-  assert(attrs({style: 'foo: bar;'}, true) === ' style="foo: bar"');
-  assert(attrs({style: 'foo: bar;'}, false) === ' style="foo: bar"');
-  assert(attrs({style: {foo: 'bar'}}, true) === ' style="foo:bar"');
-  assert(attrs({style: {foo: 'bar'}}, false) === ' style="foo:bar"');
+  assert(attrs({style: 'foo: bar;'}, true) === ' style="foo: bar;"');
+  assert(attrs({style: 'foo: bar;'}, false) === ' style="foo: bar;"');
+  assert(attrs({style: {foo: 'bar'}}, true) === ' style="foo:bar;"');
+  assert(attrs({style: {foo: 'bar'}}, false) === ' style="foo:bar;"');
 });
 
 test('classes', function (classes) {
@@ -115,24 +115,26 @@ test('merge', function (merge) {
   assert.deepEqual(merge({}, {class: ['bar']}), {class: ['bar']});
   assert.deepEqual(merge({class: ['bar']}, {}), {class: ['bar']});
 
-  assert.deepEqual(merge({style: 'foo:bar'}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash'});
-  assert.deepEqual(merge({style: 'foo:bar;'}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash'});
-  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash'});
-  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: {baz: 'bash'}}), {style: 'foo:bar;baz:bash'});
-  assert.deepEqual(merge({style: 'foo:bar'}, {style: null}), {style: 'foo:bar'});
-  assert.deepEqual(merge({style: 'foo:bar;'}, {style: null}), {style: 'foo:bar'});
-  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: null}), {style: 'foo:bar'});
-  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash'});
-  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash'});
-  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash'});
-  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash'});
-  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash'});
-  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash'});
+  assert.deepEqual(merge({style: 'foo:bar'}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash;'});
+  assert.deepEqual(merge({style: 'foo:bar;'}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash;'});
+  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: 'baz:bash'}), {style: 'foo:bar;baz:bash;'});
+  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: {baz: 'bash'}}), {style: 'foo:bar;baz:bash;'});
+  assert.deepEqual(merge({style: 'foo:bar'}, {style: null}), {style: 'foo:bar;'});
+  assert.deepEqual(merge({style: 'foo:bar;'}, {style: null}), {style: 'foo:bar;'});
+  assert.deepEqual(merge({style: {foo: 'bar'}}, {style: null}), {style: 'foo:bar;'});
+  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash;'});
+  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash;'});
+  assert.deepEqual(merge({style: null}, {style: 'baz:bash'}), {style: 'baz:bash;'});
+  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash;'});
+  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash;'});
+  assert.deepEqual(merge({}, {style: 'baz:bash'}), {style: 'baz:bash;'});
 });
 
 test('style', function (style) {
-  assert(style('foo: bar') === 'foo: bar');
-  assert(style('foo: bar;') === 'foo: bar');
-  assert(style({foo: 'bar'}) === 'foo:bar');
-  assert(style({foo: 'bar', baz: 'bash'}) === 'foo:bar;baz:bash');
+  assert(style(null) === '');
+  assert(style('') === '');
+  assert(style('foo: bar') === 'foo: bar;');
+  assert(style('foo: bar;') === 'foo: bar;');
+  assert(style({foo: 'bar'}) === 'foo:bar;');
+  assert(style({foo: 'bar', baz: 'bash'}) === 'foo:bar;baz:bash;');
 });


### PR DESCRIPTION
This PR should close pugjs/pug#2537

As per this blog post: 

http://freshinbox.com/blog/outlook-com-alters-styles-of-elements-next-to-checkboxes/

> ... if you leave off the final semicolon (;) from the inline style in the checkbox, instead of copying the style to the next element, Outlook merely…. removes the style!

```
<input type=checkbox style="display:none !important">
<div style="width:400px;">CONTENT</div>
```

> becomes:

```
<div style>CONTENT</div>
```
